### PR TITLE
python 3.x hates old version

### DIFF
--- a/mk_genesis_block.py
+++ b/mk_genesis_block.py
@@ -276,4 +276,4 @@ def evaluate():
     return g
 
 if __name__ == '__main__':
-    print json.dumps(evaluate(), indent=4)
+    print(json.dumps(evaluate(), indent=4))


### PR DESCRIPTION
Matches the example here: https://docs.python.org/3.3/library/json.html

CanaryInTheMine confirmed this fixed it for him.